### PR TITLE
Add support for event hooks

### DIFF
--- a/breadline.svnwiki
+++ b/breadline.svnwiki
@@ -83,6 +83,18 @@ Sets the word-breaking characters for completion to {{STRING}}.  The
 default value of {{\t\n\"\\'`@$><=;|&{(}} is suitable for Bash's
 completion.
 
+==== Event hooks
+
+<procedure>(event-hook-set! PROCEDURE)</procedure>
+
+Registers a hook that will be called periodically when Readline is
+waiting for terminal input. By default, this will be called at most
+ten times a second if there is no keyboard input. The argument should
+be a thunk. Its return value is ignored.
+
+Only one event hook may be registered at a time. A
+previously-registered hook may be disabled by passing {{#f}}.
+
 ==== Customization
 
 <procedure>(variable-bind! VARIABLE VALUE)</procedure>

--- a/breadline.svnwiki
+++ b/breadline.svnwiki
@@ -95,6 +95,16 @@ be a thunk. Its return value is ignored.
 Only one event hook may be registered at a time. A
 previously-registered hook may be disabled by passing {{#f}}.
 
+<procedure>(pre-input-hook-set! PROCEDURE)</procedure>
+
+Registers a hook that will be called every time the first input prompt
+has been printed, just before {{readline}} starts reading input
+characters. The argument should be a thunk. Its return value is
+ignored.
+
+Only one pre-input hook may be registered at a time. A
+previously-registered hook may be disabled by passing {{#f}}.
+
 ==== Customization
 
 <procedure>(variable-bind! VARIABLE VALUE)</procedure>


### PR DESCRIPTION
Hey Vasilij, this adds bindings for Readline's [event][] and [pre-input][] hooks.

I'm using these to set up non-blocking REPLs in `csi` so that other things can run in the background. These hooks provide two different ways to do that.

One is to use the event hook to escape from the `readline` call periodically:

``` scheme
(event-hook-set! (lambda () (thread-yield!)))
```

The other is to block on IO before `readline` blocks:

``` scheme
(pre-input-hook-set! (lambda () (thread-wait-for-i/o! 0 #:input)))
```

I tried to make the implementation similar to the completion-related code, with GC roots and hooks that start with default values (in this case noops) but can be changed with setters. Let me know if you'd like me to use a different approach.

[event]: https://tiswww.case.edu/php/chet/readline/readline.html#IDX234
[pre-input]: https://tiswww.case.edu/php/chet/readline/readline.html#IDX233