### PR TITLE
Add bindings for text modification procedures

### DIFF
--- a/breadline.scm
+++ b/breadline.scm
@@ -4,6 +4,7 @@
    completer-set! completer-word-break-characters-set!
    variable-bind! variable-value
    event-hook-set! pre-input-hook-set!
+   insert-text delete-text stuff-char redisplay
    basic-quote-characters-set! paren-blink-timeout-set!
    readline make-readline-port)
 
@@ -138,6 +139,18 @@ char *readline_completer(const char *prefix, int state) {
 
 (define paren-blink-timeout-set!
   (foreign-lambda int "rl_set_paren_blink_timeout" int))
+
+(define insert-text
+  (foreign-lambda int "rl_insert_text" (const nonnull-c-string)))
+
+(define delete-text
+  (foreign-lambda int "rl_delete_text" int int))
+
+(define stuff-char
+  (foreign-lambda int "rl_stuff_char" char))
+
+(define redisplay
+  (foreign-lambda void "rl_redisplay"))
 
 ;;; Events
 

--- a/breadline.svnwiki
+++ b/breadline.svnwiki
@@ -83,6 +83,18 @@ Sets the word-breaking characters for completion to {{STRING}}.  The
 default value of {{\t\n\"\\'`@$><=;|&{(}} is suitable for Bash's
 completion.
 
+==== Event hooks
+
+<procedure>(event-hook-set! PROCEDURE)</procedure>
+
+Registers a hook that will be called periodically when Readline is
+waiting for terminal input. By default, this will be called at most
+ten times a second if there is no keyboard input. The argument should
+be a thunk. Its return value is ignored.
+
+Only one event hook may be registered at a time. A
+previously-registered hook may be disabled by passing {{#f}}.
+
 ==== Customization
 
 <procedure>(variable-bind! VARIABLE VALUE)</procedure>

--- a/breadline.svnwiki
+++ b/breadline.svnwiki
@@ -83,6 +83,30 @@ Sets the word-breaking characters for completion to {{STRING}}.  The
 default value of {{\t\n\"\\'`@$><=;|&{(}} is suitable for Bash's
 completion.
 
+==== Text Manipulation
+
+<procedure>(insert-text STRING)</procedure>
+
+Insert {{STRING}} into the line at the current cursor position.
+Returns the number of characters inserted.
+
+<procedure>(delete-text START END)</procedure>
+
+Delete the text between {{START}} and {{END}} in the current line.
+Returns the number of characters deleted.
+
+<procedure>(stuff-char CHAR)</procedure>
+
+Insert {{CHAR}} into the Readline input stream. It will be "read"
+before Readline attempts to read characters from the terminal. Up to
+512 characters may be pushed back. Returns {{1}} if the character was
+successfully inserted; {{0}} otherwise.
+
+<procedure>(redisplay)</procedure>
+
+Change what's displayed on the screen to reflect the current contents
+of Readline's buffer.
+
 ==== Event hooks
 
 <procedure>(event-hook-set! PROCEDURE)</procedure>

--- a/breadline.svnwiki
+++ b/breadline.svnwiki
@@ -95,6 +95,16 @@ be a thunk. Its return value is ignored.
 Only one event hook may be registered at a time. A
 previously-registered hook may be disabled by passing {{#f}}.
 
+<procedure>(pre-input-hook-set! PROCEDURE)</procedure>
+
+Registers a hook that will be called every time the first input prompt
+has been printed, just before {{readline}} starts reading input
+characters. The argument should be a thunk. Its return value is
+ignored.
+
+Only one pre-input hook may be registered at a time. A
+previously-registered hook may be disabled by passing {{#f}}.
+
 ==== Customization
 
 <procedure>(variable-bind! VARIABLE VALUE)</procedure>


### PR DESCRIPTION
Here's another one that binds some of the procedures for [modifying text][1] -- just enough to manipulate the buffer and send a newline.

As motivation, here's an example of sending text to a running `readline` prompt from another thread:

``` scheme
(import (breadline))
(import (chicken repl))
(import (srfi 18))

(current-input-port (make-readline-port))

(event-hook-set! (lambda () (thread-yield!)))

(thread-start!
 (lambda ()
   (for-each (lambda (c)
               (thread-sleep! 0.1)
               (stuff-char c)
               (redisplay))
             (string->list "(print \"Hello wasamasa!\")\n"))))

(repl (lambda (x) (eval x) (exit)))
```

[1]: https://tiswww.case.edu/php/chet/readline/readline.html#SEC36

Note that this is based on #1 -- if you're happy with that PR I'll rebase this once it's merged.